### PR TITLE
Add robust test suite (unit + integration)

### DIFF
--- a/core_helpers.py
+++ b/core_helpers.py
@@ -1,0 +1,5 @@
+# core_helpers.py
+
+def seconds_to_frames(seconds: float, fps: int) -> int:
+    """Convert seconds to frame number using the given FPS."""
+    return int(seconds * fps)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest>=8
+pytest-mock
+coverage
+pillow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+import sys, types, pathlib
+
+# --- Mock mínimo do módulo bpy para testes unitários ---
+def _mock_bpy():
+    mock = types.ModuleType("bpy")
+    mock.context = types.SimpleNamespace(scene=types.SimpleNamespace(
+        sequence_editor=None,
+        sequence_editor_create=lambda: None,
+    ))
+    class _Movie:
+        frame_duration = 24
+    mock.data = types.SimpleNamespace(movieclips=types.SimpleNamespace(
+        load=lambda path: _Movie()
+    ))
+    sys.modules["bpy"] = mock
+
+_mock_bpy()
+
+# --- Fixture: diretório raiz do projeto ---
+import pytest, os
+
+@pytest.fixture(scope="session")
+def project_root():
+    return pathlib.Path(__file__).resolve().parents[1]
+
+# --- Fixture para gerar mini assets de vídeo e áudio ---
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_assets(project_root):
+    assets = project_root / "tests" / "integration" / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    video = assets / "video.mp4"
+    audio = assets / "audio.wav"
+    if not video.exists():
+        with open(video, "wb") as f:
+            f.write(b"\x00")
+    if not audio.exists():
+        with open(audio, "wb") as f:
+            f.write(b"\x00")
+    return assets

--- a/tests/integration/test_json_flow.py
+++ b/tests/integration/test_json_flow.py
@@ -1,0 +1,98 @@
+import shutil
+import os
+import runpy
+import sys
+import types
+
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from generate_project import generate_project_file
+
+
+def test_json_flow(tmp_path, project_root, prepare_assets, monkeypatch):
+    # copy required scripts into temp dir
+    shutil_src = project_root / "blender_script_template.py"
+    core_src = project_root / "blender_core.py"
+    shutil.copy(shutil_src, tmp_path / "blender_script_template.py")
+    shutil.copy(core_src, tmp_path / "blender_core.py")
+
+    video = prepare_assets / "video.mp4"
+    audio = prepare_assets / "audio.wav"
+
+    config = {
+        "videos": [{"path": str(video), "channel": 1, "start_frame": 1, "name": "vid"}],
+        "audios": [{"path": str(audio), "channel": 2, "start_frame": 1, "name": "aud"}],
+        "images": [],
+        "output_path": "output/final.mp4",
+        "resolution_x": 64,
+        "resolution_y": 64,
+        "fps": 24,
+        "operations": []
+    }
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        generate_project_file(config)
+
+        # Prepare fake bpy for this integration test
+        seq_data = []
+        fake_bpy = types.SimpleNamespace(
+            context=types.SimpleNamespace(scene=types.SimpleNamespace(
+                sequence_editor=types.SimpleNamespace(sequences_all=seq_data),
+                sequence_editor_create=lambda: None,
+                render=types.SimpleNamespace()
+            )),
+            data=types.SimpleNamespace(movieclips=types.SimpleNamespace(
+                load=lambda p: types.SimpleNamespace(frame_duration=24),
+                remove=lambda x: None
+            )),
+            ops=types.SimpleNamespace(
+                render=types.SimpleNamespace(render=lambda animation=True: None),
+                sequencer=types.SimpleNamespace(select_all=lambda action=None: None,
+                                                delete=lambda: None,
+                                                split=lambda frame=None, type=None, side=None: None,
+                                                meta_make=lambda: None)
+            )
+        )
+        monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+
+        # stub all blender_core functions to just append calls
+        import blender_core
+
+        def fake_init_sequence(fps):
+            fake_bpy.context.scene.sequence_editor.sequences_all = []
+            return fake_bpy.context.scene.sequence_editor.sequences_all
+
+        def fake_add_video_strip(path, channel=1, frame_start=1):
+            seq = types.SimpleNamespace(name=os.path.basename(path))
+            fake_bpy.context.scene.sequence_editor.sequences_all.append(seq)
+            return seq
+
+        def fake_add_audio_strip(path, channel=2, frame_start=1):
+            seq = types.SimpleNamespace(name=os.path.basename(path))
+            fake_bpy.context.scene.sequence_editor.sequences_all.append(seq)
+            return seq
+
+        def fake_add_image_strip(path, channel=3, frame_start=1, frame_end=None):
+            seq = types.SimpleNamespace(name=os.path.basename(path))
+            fake_bpy.context.scene.sequence_editor.sequences_all.append(seq)
+            return seq
+
+        monkeypatch.setattr(blender_core, "init_sequence", fake_init_sequence)
+        monkeypatch.setattr(blender_core, "add_video_strip", fake_add_video_strip)
+        monkeypatch.setattr(blender_core, "add_audio_strip", fake_add_audio_strip)
+        monkeypatch.setattr(blender_core, "add_image_strip", fake_add_image_strip)
+        monkeypatch.setattr(blender_core, "split_strip", lambda *a, **k: None)
+        monkeypatch.setattr(blender_core, "delete_strip", lambda *a, **k: None)
+        monkeypatch.setattr(blender_core, "merge_strips", lambda *a, **k: None)
+        monkeypatch.setattr(blender_core, "transform_strip", lambda *a, **k: None)
+        monkeypatch.setattr(blender_core, "finalize_render", lambda *a, **k: None)
+
+        runpy.run_path(str(tmp_path / "blender_script.py"), run_name="__main__")
+        assert len(fake_bpy.context.scene.sequence_editor.sequences_all) >= 2
+    finally:
+        os.chdir(cwd)

--- a/tests/integration/test_render_cli.py
+++ b/tests/integration/test_render_cli.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from generate_project import generate_project_file
+
+blender = shutil.which("blender")
+if not blender:
+    pytest.skip("Blender CLI not installed", allow_module_level=True)
+
+
+def test_render_cli(tmp_path, project_root, prepare_assets):
+    shutil.copy(project_root / "blender_script_template.py", tmp_path / "blender_script_template.py")
+    shutil.copy(project_root / "blender_core.py", tmp_path / "blender_core.py")
+
+    config = {
+        "videos": [{"path": str(prepare_assets / "video.mp4"), "channel": 1, "start_frame": 1, "name": "vid"}],
+        "audios": [{"path": str(prepare_assets / "audio.wav"), "channel": 2, "start_frame": 1, "name": "aud"}],
+        "images": [],
+        "output_path": "output/final.mp4",
+        "resolution_x": 64,
+        "resolution_y": 64,
+        "fps": 24,
+        "operations": []
+    }
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        generate_project_file(config)
+        cmd = [blender, "-b", "-P", "blender_script.py", "--", "config/project_config.json"]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        assert result.returncode == 0
+        assert "Finished Rendering" in result.stdout
+        out = tmp_path / "output" / "final.mp4"
+        assert out.exists()
+        assert out.stat().st_size > 0
+    finally:
+        os.chdir(cwd)

--- a/tests/unit/test_core_helpers.py
+++ b/tests/unit/test_core_helpers.py
@@ -1,0 +1,16 @@
+import pytest, sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from core_helpers import seconds_to_frames
+from blender_core import add_video_strip
+
+
+def test_seconds_to_frames():
+    assert seconds_to_frames(2.5, 24) == 60
+
+
+def test_add_video_strip_missing(tmp_path):
+    missing = tmp_path / "no_video.mp4"
+    with pytest.raises(FileNotFoundError):
+        add_video_strip(str(missing))

--- a/tests/unit/test_generate_project.py
+++ b/tests/unit/test_generate_project.py
@@ -4,13 +4,13 @@ import shutil
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
 
 from generate_project import generate_project_file
 
 
-def test_generate_project_file(tmp_path):
+def test_generate_project_file(tmp_path, project_root):
     config = {
         "videos": [],
         "audios": [],
@@ -18,9 +18,8 @@ def test_generate_project_file(tmp_path):
         "operations": []
     }
 
-    template_src = os.path.join(os.path.dirname(__file__), os.pardir, "blender_script_template.py")
-    template_dst = tmp_path / "blender_script_template.py"
-    shutil.copy(template_src, template_dst)
+    template_src = project_root / "blender_script_template.py"
+    shutil.copy(template_src, tmp_path / "blender_script_template.py")
 
     cwd = os.getcwd()
     os.chdir(tmp_path)
@@ -33,4 +32,3 @@ def test_generate_project_file(tmp_path):
         assert data == config
     finally:
         os.chdir(cwd)
-


### PR DESCRIPTION
## Summary
- introduce development requirements
- mock minimal `bpy` and mini-asset fixtures in `conftest`
- add helper `seconds_to_frames`
- add unit tests for core helpers and project generation
- add integration tests covering JSON flow and optional render CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456da738f08322bdac29928a55d4e6